### PR TITLE
Fix deprecations

### DIFF
--- a/objc.mustache
+++ b/objc.mustache
@@ -98,8 +98,8 @@ static NSString* NSStringFromQueryParameters(NSDictionary* queryParameters)
     NSMutableArray* parts = [NSMutableArray array];
     [queryParameters enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL *stop) {
         NSString *part = [NSString stringWithFormat: @"%@=%@",
-            [key stringByAddingPercentEscapesUsingEncoding: NSUTF8StringEncoding],
-            [value stringByAddingPercentEscapesUsingEncoding: NSUTF8StringEncoding]
+            [key stringByAddingPercentEncodingWithAllowedCharacters: [NSCharacterSet URLQueryAllowedCharacterSet]],
+            [value stringByAddingPercentEncodingWithAllowedCharacters: [NSCharacterSet URLQueryAllowedCharacterSet]]
         ];
         [parts addObject:part];
     }];


### PR DESCRIPTION
From the [documentation](https://developer.apple.com/documentation/foundation/nsstring/1415058-stringbyaddingpercentescapesusin):

> `stringByAddingPercentEscapesUsingEncoding:` is deprecated: first deprecated in iOS 9.0 - Use `-stringByAddingPercentEncodingWithAllowedCharacters:` instead, which always uses the recommended UTF-8 encoding, and which encodes for a specific URL component or subcomponent since each URL component or subcomponent has different rules for what characters are valid.

So I replaced this method in the exported file and since we’re dealing with the query here we can encode the string via `URLQueryAllowedCharacterSet`. This makes the exported code easier to use. What do you think?